### PR TITLE
Feat: Add access to deployed services

### DIFF
--- a/Agent.Cli/CliConfig.cs
+++ b/Agent.Cli/CliConfig.cs
@@ -3,5 +3,7 @@ namespace Agent.Cli;
 public sealed record CliConfig(Uri BaseAddress)
 {
     public static readonly CliConfig Default =
-        new(new Uri("http://localhost:5165/v1/"));
+        new(new Uri(Environment.GetEnvironmentVariable("SLICE_AGENT_URL") is { } url
+            ? url.TrimEnd('/') + "/v1/"
+            : "http://localhost:5165/v1/"));
 }

--- a/Agent.Cli/Commands/DeployServiceCommand.cs
+++ b/Agent.Cli/Commands/DeployServiceCommand.cs
@@ -2,24 +2,34 @@ using System.CommandLine;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Agent.Cli.Core;
 using Agent.Cli.Core.Events;
 using Agent.Cli.Core.Results;
 using Agent.Cli.Presentation;
+using Agent.Cli.Serialization;
 using Agent.Cli.Utils;
+using Slice.Common.Models;
 
 namespace Agent.Cli.Commands;
 
-public class DeployServiceCommand(string targetName, HttpClient httpClient) : ICommand
+public class DeployServiceCommand(string targetName, bool publish, string? domain, HttpClient httpClient) : ICommand
 {
   public static void Register(RootCommand root, HttpClient httpClient)
   {
     var targetArg = new Argument<string>("target") { Description = "The .NET project name or .csproj path to deploy" };
-    var command = new Command("deploy", "Deploy a .NET service") { targetArg };
+    var publishOpt = new Option<bool>("--publish") { Description = "Expose the app publicly via the reverse proxy" };
+    var domainOpt = new Option<string?>("--domain") { Description = "Custom domain. Defaults to <appname>.<base-domain>" };
+
+    var command = new Command("deploy", "Deploy a .NET service") { targetArg, publishOpt, domainOpt };
 
     command.SetAction(async (parseResult, ct) =>
     {
-      var cmd = new DeployServiceCommand(parseResult.GetValue(targetArg)!, httpClient);
+      var cmd = new DeployServiceCommand(
+          parseResult.GetValue(targetArg)!,
+          parseResult.GetValue(publishOpt),
+          parseResult.GetValue(domainOpt),
+          httpClient);
       return await ConsoleRenderer.RenderAsync(cmd.ExecuteStreamingAsync(ct), ct);
     });
 
@@ -69,7 +79,13 @@ public class DeployServiceCommand(string targetName, HttpClient httpClient) : IC
       yield break;
     }
     yield return new StepCompleted("Uploading to deployment service", TimeSpan.Zero);
-    yield return new FinalResult(new SuccessResult($"Deployment complete: {uploadResult.response}"));
+
+    var result = uploadResult.result!;
+    var message = result.PublicUrl is { } url
+        ? $"Deployed {result.AppName} → {url}"
+        : $"Deployed {result.AppName} (localhost only)";
+
+    yield return new FinalResult(new SuccessResult(message));
   }
 
   private (string? filePath, ErrorResult? error) TryFindProject(CancellationToken ct)
@@ -171,23 +187,28 @@ public class DeployServiceCommand(string targetName, HttpClient httpClient) : IC
     }
   }
 
-  private async Task<(string? response, ErrorResult? error)> TryUploadAsync(MemoryStream zipStream, string fileName, CancellationToken ct)
+  private async Task<(DeployResult? result, ErrorResult? error)> TryUploadAsync(MemoryStream zipStream, string fileName, CancellationToken ct)
   {
     try
     {
       using var content = new ProgressStreamContent(zipStream);
       using var multipart = new MultipartFormDataContent();
       multipart.Add(content, "file", fileName);
+      multipart.Add(new StringContent(publish ? "true" : "false"), "publish");
+      if (domain is not null)
+        multipart.Add(new StringContent(domain), "domain");
+
       var uploadResult = await httpClient.PostAsync("services", multipart, ct);
 
       if (!uploadResult.IsSuccessStatusCode)
       {
-        var error = await uploadResult.Content.ReadAsStringAsync();
+        var error = await uploadResult.Content.ReadAsStringAsync(ct);
         return (null, new ErrorResult($"Error: {uploadResult.StatusCode}. {error}"));
       }
 
-      var response = await uploadResult.Content.ReadAsStringAsync();
-      return (response, null);
+      var body = await uploadResult.Content.ReadAsStringAsync(ct);
+      var result = JsonSerializer.Deserialize(body, CliJsonContext.Default.DeployResult);
+      return (result, null);
     }
     catch (HttpRequestException ex)
     {

--- a/Agent.Cli/Commands/DeployServiceCommand.cs
+++ b/Agent.Cli/Commands/DeployServiceCommand.cs
@@ -47,7 +47,6 @@ public class DeployServiceCommand(string targetName, bool publish, string? domai
       yield break;
     }
 
-    // Step 1: Find project
     yield return new StepStarted("Finding project files");
     var findResult = TryFindProject(ct);
     if (findResult.error is ErrorResult findError)
@@ -57,7 +56,6 @@ public class DeployServiceCommand(string targetName, bool publish, string? domai
     }
     yield return new StepCompleted("Finding project files", TimeSpan.Zero);
 
-    // Step 2: Build
     yield return new StepStarted("Building project");
     var buildResult = await TryBuildProjectAsync(findResult.filePath!, ct);
     if (buildResult.error is ErrorResult buildError)
@@ -67,7 +65,6 @@ public class DeployServiceCommand(string targetName, bool publish, string? domai
     }
     yield return new StepCompleted("Building project", TimeSpan.Zero);
 
-    // Step 3: Create package
     yield return new StepStarted("Creating deployment package");
     var packageResult = TryCreatePackage(buildResult.publishPath!);
     if (packageResult.error is ErrorResult packageError)
@@ -77,7 +74,6 @@ public class DeployServiceCommand(string targetName, bool publish, string? domai
     }
     yield return new StepCompleted("Creating deployment package", TimeSpan.Zero);
 
-    // Step 4: Upload
     yield return new StepStarted("Uploading to deployment service");
     var uploadResult = await TryUploadAsync(packageResult.zipStream!, packageResult.fileName!, ct);
     if (uploadResult.error is ErrorResult uploadError)

--- a/Agent.Cli/Commands/DeployServiceCommand.cs
+++ b/Agent.Cli/Commands/DeployServiceCommand.cs
@@ -40,6 +40,13 @@ public class DeployServiceCommand(string targetName, bool publish, string? domai
   public async IAsyncEnumerable<ExecutionEvent> ExecuteStreamingAsync(
       [EnumeratorCancellation] CancellationToken ct = default)
   {
+    if (domain is not null && !publish)
+    {
+      yield return new FinalResult(new ErrorResult(
+          "--domain requires --publish. Did you mean: slice deploy <target> --publish --domain <domain>?", 1));
+      yield break;
+    }
+
     // Step 1: Find project
     yield return new StepStarted("Finding project files");
     var findResult = TryFindProject(ct);

--- a/Agent.Cli/Commands/DeployServiceCommand.cs
+++ b/Agent.Cli/Commands/DeployServiceCommand.cs
@@ -80,7 +80,12 @@ public class DeployServiceCommand(string targetName, bool publish, string? domai
     }
     yield return new StepCompleted("Uploading to deployment service", TimeSpan.Zero);
 
-    var result = uploadResult.result!;
+    var result = uploadResult.result;
+    if (result is null)
+    {
+      yield return new StepFailed("Uploading to deployment service", "Unknown error, results are null");
+      yield break;
+    }
     var message = result.PublicUrl is { } url
         ? $"Deployed {result.AppName} → {url}"
         : $"Deployed {result.AppName} (localhost only)";

--- a/Agent.Cli/Serialization/CliJsonContext.cs
+++ b/Agent.Cli/Serialization/CliJsonContext.cs
@@ -6,5 +6,6 @@ namespace Agent.Cli.Serialization;
 [JsonSerializable(typeof(SystemdService))]
 [JsonSerializable(typeof(List<SystemdService>))]
 [JsonSerializable(typeof(ServiceStatus))]
+[JsonSerializable(typeof(DeployResult))]
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 public partial class CliJsonContext : JsonSerializerContext { }

--- a/Agent/Configuration/ReverseProxyOptions.cs
+++ b/Agent/Configuration/ReverseProxyOptions.cs
@@ -1,0 +1,8 @@
+namespace Agent.Configuration;
+
+public class ReverseProxyOptions
+{
+    public const string SectionName = "ReverseProxy";
+    public string AdminUrl { get; set; } = "http://localhost:2019";
+    public string BaseDomain { get; set; } = string.Empty;
+}

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -1,8 +1,12 @@
 using System.Net;
+using Agent.Configuration;
 using Agent.Serialization;
 using Agent.Services;
 using Agent.Services.Exceptions;
+using Agent.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Slice.Common.Models;
 
 
 var builder = WebApplication.CreateSlimBuilder(args);
@@ -11,15 +15,24 @@ var builder = WebApplication.CreateSlimBuilder(args);
 builder.Services.AddOpenApi();
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
-  // This makes the API use your source-generated context globally
   options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default);
 });
+
 var systemdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config/systemd/user/");
 
 builder.Services.AddTransient<IFileNamingService, FileNamingService>();
 builder.Services.AddSingleton<IPortManager, PortManager>();
 builder.Services.AddTransient(sp =>
         new ProcessManager(systemdPath, sp.GetRequiredService<IPortManager>()));
+
+builder.Services.Configure<ReverseProxyOptions>(
+    builder.Configuration.GetSection(ReverseProxyOptions.SectionName));
+
+builder.Services.AddHttpClient<IReverseProxyClient, CaddyClient>((sp, client) =>
+{
+  var opts = sp.GetRequiredService<IOptions<ReverseProxyOptions>>().Value;
+  client.BaseAddress = new Uri(opts.AdminUrl);
+});
 
 var app = builder.Build();
 
@@ -30,7 +43,14 @@ if (app.Environment.IsDevelopment())
 
 
 
-app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (IFormFile file, ProcessManager processRunner, IFileNamingService namingService) =>
+app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
+    IFormFile file,
+    [FromForm] bool publish,
+    [FromForm] string? domain,
+    ProcessManager processRunner,
+    IFileNamingService namingService,
+    IReverseProxyClient proxy,
+    IOptions<ReverseProxyOptions> proxyOptions) =>
 {
   try
   {
@@ -46,9 +66,22 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (IFormFile file
       return Results.Problem(detail: $"No runnable DLL '{dllName}.dll' found in uploaded archive.",
                              statusCode: (int)HttpStatusCode.BadRequest);
 
-    await processRunner.CreateSystemdService(appSafePath, dllName);
+    var port = await processRunner.CreateSystemdService(appSafePath, dllName);
 
-    return Results.Accepted($"{appSafePath} Accepted");
+    string? publicUrl = null;
+    if (publish)
+    {
+      var opts = proxyOptions.Value;
+      if (string.IsNullOrEmpty(opts.BaseDomain) && domain is null)
+        return Results.Problem(detail: "ReverseProxy:BaseDomain is not configured. Provide --domain explicitly.",
+                               statusCode: (int)HttpStatusCode.BadRequest);
+
+      var targetDomain = domain ?? $"{appSafePath}.{opts.BaseDomain}";
+      await proxy.RegisterRouteAsync(appSafePath, targetDomain, port);
+      publicUrl = $"https://{targetDomain}";
+    }
+
+    return Results.Ok(new DeployResult(appSafePath, publicUrl));
   }
   catch (ArgumentException ex)
   {

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -52,9 +52,10 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
     IReverseProxyClient proxy,
     IOptions<ReverseProxyOptions> proxyOptions) =>
 {
+  string? appSafePath = null;
   try
   {
-    string appSafePath = namingService.GetSafeAppName(file.FileName);
+    appSafePath = namingService.GetSafeAppName(file.FileName);
     string displayName = namingService.GetRawAppName(file.FileName);
     string dllName = Path.GetFileNameWithoutExtension(file.FileName);
     var uploadPath = namingService.GetUploadPath(appSafePath);
@@ -106,6 +107,24 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
   {
     return Results.Problem(detail: ex.Message, statusCode: (int)HttpStatusCode.BadRequest);
   }
+  catch (OutOfPortsException ex)
+  {
+    return Results.Problem(detail: ex.Message,
+                           statusCode: (int)HttpStatusCode.ServiceUnavailable);
+  }
+  catch (SystemctlException ex)
+  {
+    return Results.Problem(detail: ex.Message,
+                           statusCode: (int)HttpStatusCode.InternalServerError);
+  }
+  catch (HttpRequestException ex)
+  {
+    if (appSafePath is not null)
+      await processRunner.StopServiceAsync(appSafePath);
+    return Results.Problem(
+        detail: $"Caddy route registration failed: {ex.Message}. Service was stopped.",
+        statusCode: (int)HttpStatusCode.BadGateway);
+  }
 }).DisableAntiforgery();
 
 app.MapGet("v1/services", async (ProcessManager processRunner) =>
@@ -125,7 +144,7 @@ app.MapGet("v1/services/{serviceName}", async (string serviceName, ProcessManage
 {
   try
   {
-    var service = await processRunner.GetServiceStatusAsync(serviceName);
+    var service = await processRunner.GetServiceStatusAsync($"slice-{serviceName}");
     if (service == null)
       return Results.NotFound();
 
@@ -139,7 +158,7 @@ app.MapGet("v1/services/{serviceName}", async (string serviceName, ProcessManage
 
 app.MapPost("v1/services/{serviceName}/stop", async (string serviceName, ProcessManager processManager) =>
 {
-  var stopped = await processManager.StopServiceAsync(serviceName);
+  var stopped = await processManager.StopServiceAsync($"slice-{serviceName}");
   return stopped
       ? Results.NoContent()
       : Results.Problem(detail: $"Failed to stop service '{serviceName}'. Make sure the service exists and is running.",
@@ -147,11 +166,3 @@ app.MapPost("v1/services/{serviceName}/stop", async (string serviceName, Process
 });
 
 app.Run();
-
-
-static (string, string) ConstructCustomDomainUrl(string appName, int port)
-{
-  var domain = appName + ".localhost";
-  var url = $"http://{domain}:{port}";
-  return (domain, url);
-}

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -64,8 +64,10 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
 
     var dllPath = Path.Combine(Path.GetFullPath(uploadPath), dllName + ".dll");
     if (!File.Exists(dllPath))
+    {
       return Results.Problem(detail: $"No runnable DLL '{dllName}.dll' found in uploaded archive.",
                              statusCode: (int)HttpStatusCode.BadRequest);
+    }
 
     var port = await processRunner.CreateSystemdService(appSafePath, dllName);
 
@@ -74,10 +76,18 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
     {
       var opts = proxyOptions.Value;
       if (string.IsNullOrEmpty(opts.BaseDomain) && domain is null)
+      {
         return Results.Problem(detail: "ReverseProxy:BaseDomain is not configured. Provide --domain explicitly.",
                                statusCode: (int)HttpStatusCode.BadRequest);
+      }
+      if (!namingService.IsDomainValid(domain))
+      {
+        return Results.Problem(detail: $"Provided domain '{domain}' is not valid.",
+                               statusCode: (int)HttpStatusCode.BadRequest);
+      }
 
       var targetDomain = domain ?? $"{displayName}.{opts.BaseDomain}";
+
       if (targetDomain.EndsWith(opts.BaseDomain) && string.IsNullOrEmpty(opts.BaseDomain))
       {
         var (defaultCustomDomain, _) = ConstructCustomDomainUrl(displayName, port);

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -20,7 +20,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 
 var systemdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config/systemd/user/");
 
-builder.Services.AddTransient<IFileNamingService, FileNamingService>();
+builder.Services.AddTransient<FileNamingService>();
 builder.Services.AddSingleton<IPortManager, PortManager>();
 builder.Services.AddTransient(sp =>
         new ProcessManager(systemdPath, sp.GetRequiredService<IPortManager>()));
@@ -48,7 +48,7 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
     [FromForm] bool publish,
     [FromForm] string? domain,
     ProcessManager processRunner,
-    IFileNamingService namingService,
+    FileNamingService namingService,
     IReverseProxyClient proxy,
     IOptions<ReverseProxyOptions> proxyOptions) =>
 {

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -69,7 +69,6 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
                              statusCode: (int)HttpStatusCode.BadRequest);
     }
 
-    var port = await processRunner.CreateSystemdService(appSafePath, dllName);
 
     string? publicUrl = null;
     if (publish)
@@ -86,6 +85,7 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
                                statusCode: (int)HttpStatusCode.BadRequest);
       }
 
+      var port = await processRunner.CreateSystemdService(appSafePath, dllName);
       var targetDomain = domain ?? $"{displayName}.{opts.BaseDomain}";
 
       if (targetDomain.EndsWith(opts.BaseDomain) && string.IsNullOrEmpty(opts.BaseDomain))

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -78,6 +78,11 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
                                statusCode: (int)HttpStatusCode.BadRequest);
 
       var targetDomain = domain ?? $"{displayName}.{opts.BaseDomain}";
+      if (targetDomain.EndsWith(opts.BaseDomain) && string.IsNullOrEmpty(opts.BaseDomain))
+      {
+        var (defaultCustomDomain, _) = ConstructCustomDomainUrl(displayName, port);
+        targetDomain = defaultCustomDomain;
+      }
       await proxy.RegisterRouteAsync(appSafePath, targetDomain, port);
       publicUrl = $"https://{targetDomain}";
     }
@@ -134,3 +139,11 @@ app.MapPost("v1/services/{serviceName}/stop", async (string serviceName, Process
 });
 
 app.Run();
+
+
+static (string, string) ConstructCustomDomainUrl(string appName, int port)
+{
+  var domain = appName + ".localhost";
+  var url = $"http://{domain}:{port}";
+  return (domain, url);
+}

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -119,11 +119,11 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
   }
   catch (HttpRequestException ex)
   {
-    if (appSafePath is not null)
-      await processRunner.StopServiceAsync(appSafePath);
-    return Results.Problem(
-        detail: $"Caddy route registration failed: {ex.Message}. Service was stopped.",
-        statusCode: (int)HttpStatusCode.BadGateway);
+    var rolled = await processRunner.StopServiceAsync(appSafePath!);
+    var detail = rolled
+        ? $"Caddy route registration failed: {ex.Message}. Service was rolled back."
+        : $"Caddy route registration failed: {ex.Message}. Service rollback also failed — stop it manually.";
+    return Results.Problem(detail: detail, statusCode: (int)HttpStatusCode.BadGateway);
   }
 }).DisableAntiforgery();
 
@@ -144,7 +144,7 @@ app.MapGet("v1/services/{serviceName}", async (string serviceName, ProcessManage
 {
   try
   {
-    var service = await processRunner.GetServiceStatusAsync($"slice-{serviceName}");
+    var service = await processRunner.GetServiceStatusAsync($"{FileNamingService.FilePrefix}-{serviceName}");
     if (service == null)
       return Results.NotFound();
 
@@ -158,7 +158,7 @@ app.MapGet("v1/services/{serviceName}", async (string serviceName, ProcessManage
 
 app.MapPost("v1/services/{serviceName}/stop", async (string serviceName, ProcessManager processManager) =>
 {
-  var stopped = await processManager.StopServiceAsync($"slice-{serviceName}");
+  var stopped = await processManager.StopServiceAsync($"{FileNamingService.FilePrefix}-{serviceName}");
   return stopped
       ? Results.NoContent()
       : Results.Problem(detail: $"Failed to stop service '{serviceName}'. Make sure the service exists and is running.",

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -69,8 +69,7 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
                              statusCode: (int)HttpStatusCode.BadRequest);
     }
 
-
-    string? publicUrl = null;
+    string? targetDomain = null;
     if (publish)
     {
       var opts = proxyOptions.Value;
@@ -79,20 +78,19 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
         return Results.Problem(detail: "ReverseProxy:BaseDomain is not configured. Provide --domain explicitly.",
                                statusCode: (int)HttpStatusCode.BadRequest);
       }
-      if (!namingService.IsDomainValid(domain))
+      if (domain is not null && !namingService.IsDomainValid(domain))
       {
         return Results.Problem(detail: $"Provided domain '{domain}' is not valid.",
                                statusCode: (int)HttpStatusCode.BadRequest);
       }
+      targetDomain = domain ?? $"{displayName}.{opts.BaseDomain}";
+    }
 
-      var port = await processRunner.CreateSystemdService(appSafePath, dllName);
-      var targetDomain = domain ?? $"{displayName}.{opts.BaseDomain}";
+    var port = await processRunner.CreateSystemdService(appSafePath, dllName, targetDomain);
 
-      if (targetDomain.EndsWith(opts.BaseDomain) && string.IsNullOrEmpty(opts.BaseDomain))
-      {
-        var (defaultCustomDomain, _) = ConstructCustomDomainUrl(displayName, port);
-        targetDomain = defaultCustomDomain;
-      }
+    string? publicUrl = null;
+    if (targetDomain is not null)
+    {
       await proxy.RegisterRouteAsync(appSafePath, targetDomain, port);
       publicUrl = $"https://{targetDomain}";
     }

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -55,6 +55,7 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
   try
   {
     string appSafePath = namingService.GetSafeAppName(file.FileName);
+    string displayName = namingService.GetRawAppName(file.FileName);
     string dllName = Path.GetFileNameWithoutExtension(file.FileName);
     var uploadPath = namingService.GetUploadPath(appSafePath);
     Directory.CreateDirectory(uploadPath);
@@ -76,12 +77,12 @@ app.MapPost("v1/services", [RequestSizeLimit(100_000_000)] async (
         return Results.Problem(detail: "ReverseProxy:BaseDomain is not configured. Provide --domain explicitly.",
                                statusCode: (int)HttpStatusCode.BadRequest);
 
-      var targetDomain = domain ?? $"{appSafePath}.{opts.BaseDomain}";
+      var targetDomain = domain ?? $"{displayName}.{opts.BaseDomain}";
       await proxy.RegisterRouteAsync(appSafePath, targetDomain, port);
       publicUrl = $"https://{targetDomain}";
     }
 
-    return Results.Ok(new DeployResult(appSafePath, publicUrl));
+    return Results.Ok(new DeployResult(displayName, publicUrl));
   }
   catch (ArgumentException ex)
   {

--- a/Agent/Serialization/AppJsonContext.cs
+++ b/Agent/Serialization/AppJsonContext.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Slice.Common.Models;
 using Microsoft.AspNetCore.Mvc;
+using Agent.Services;
 
 namespace Agent.Serialization;
 
@@ -10,6 +11,8 @@ namespace Agent.Serialization;
 [JsonSerializable(typeof(SystemdService))]
 [JsonSerializable(typeof(List<SystemdService>))]
 [JsonSerializable(typeof(ServiceStatus))]
+[JsonSerializable(typeof(DeployResult))]
+[JsonSerializable(typeof(CaddyRoute))]
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 public partial class AppJsonContext : JsonSerializerContext { }
 

--- a/Agent/Services/CaddyClient.cs
+++ b/Agent/Services/CaddyClient.cs
@@ -1,0 +1,47 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Agent.Serialization;
+using Agent.Services.Interfaces;
+
+namespace Agent.Services;
+
+public class CaddyClient(HttpClient http) : IReverseProxyClient
+{
+    public async Task RegisterRouteAsync(string appName, string domain, int port, CancellationToken ct = default)
+    {
+        var route = new CaddyRoute(
+            $"slice-{appName}",
+            [new CaddyMatch([domain])],
+            [new CaddyHandle("reverse_proxy", [new CaddyUpstream($"localhost:{port}")])]
+        );
+
+        using var content = JsonContent.Create(route, AppJsonContext.Default.CaddyRoute);
+        var response = await http.PostAsync("/config/apps/http/servers/srv0/routes", content, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task RemoveRouteAsync(string appName, CancellationToken ct = default)
+    {
+        var response = await http.DeleteAsync($"/id/slice-{appName}", ct);
+        response.EnsureSuccessStatusCode();
+    }
+}
+
+public record CaddyRoute(
+    [property: JsonPropertyName("@id")] string Id,
+    [property: JsonPropertyName("match")] CaddyMatch[] Match,
+    [property: JsonPropertyName("handle")] CaddyHandle[] Handle
+);
+
+public record CaddyMatch(
+    [property: JsonPropertyName("host")] string[] Host
+);
+
+public record CaddyHandle(
+    [property: JsonPropertyName("handler")] string Handler,
+    [property: JsonPropertyName("upstreams")] CaddyUpstream[] Upstreams
+);
+
+public record CaddyUpstream(
+    [property: JsonPropertyName("dial")] string Dial
+);

--- a/Agent/Services/CaddyClient.cs
+++ b/Agent/Services/CaddyClient.cs
@@ -7,24 +7,24 @@ namespace Agent.Services;
 
 public class CaddyClient(HttpClient http) : IReverseProxyClient
 {
-    public async Task RegisterRouteAsync(string appName, string domain, int port, CancellationToken ct = default)
-    {
-        var route = new CaddyRoute(
-            $"slice-{appName}",
-            [new CaddyMatch([domain])],
-            [new CaddyHandle("reverse_proxy", [new CaddyUpstream($"localhost:{port}")])]
-        );
+  public async Task RegisterRouteAsync(string appName, string domain, int port, CancellationToken ct = default)
+  {
+    var route = new CaddyRoute(
+        appName,
+        [new CaddyMatch([domain])],
+        [new CaddyHandle("reverse_proxy", [new CaddyUpstream($"localhost:{port}")])]
+    );
 
-        using var content = JsonContent.Create(route, AppJsonContext.Default.CaddyRoute);
-        var response = await http.PostAsync("/config/apps/http/servers/srv0/routes", content, ct);
-        response.EnsureSuccessStatusCode();
-    }
+    using var content = JsonContent.Create(route, AppJsonContext.Default.CaddyRoute);
+    var response = await http.PostAsync("/config/apps/http/servers/srv0/routes", content, ct);
+    response.EnsureSuccessStatusCode();
+  }
 
-    public async Task RemoveRouteAsync(string appName, CancellationToken ct = default)
-    {
-        var response = await http.DeleteAsync($"/id/slice-{appName}", ct);
-        response.EnsureSuccessStatusCode();
-    }
+  public async Task RemoveRouteAsync(string appName, CancellationToken ct = default)
+  {
+    var response = await http.DeleteAsync($"/id/slice-{appName}", ct);
+    response.EnsureSuccessStatusCode();
+  }
 }
 
 public record CaddyRoute(

--- a/Agent/Services/CaddyClient.cs
+++ b/Agent/Services/CaddyClient.cs
@@ -22,7 +22,7 @@ public class CaddyClient(HttpClient http) : IReverseProxyClient
 
   public async Task RemoveRouteAsync(string appName, CancellationToken ct = default)
   {
-    var response = await http.DeleteAsync($"/id/slice-{appName}", ct);
+    var response = await http.DeleteAsync($"/id/{appName}", ct);
     response.EnsureSuccessStatusCode();
   }
 }

--- a/Agent/Services/FileNamingService.cs
+++ b/Agent/Services/FileNamingService.cs
@@ -5,7 +5,7 @@ namespace Agent.Services;
 public partial class FileNamingService
 {
   private const string AllowedExtension = ".zip";
-  private const string FilePrefix = "slice";
+  internal const string FilePrefix = "slice";
 
   [GeneratedRegex(@"[^a-zA-Z0-9-]")]
   private static partial Regex SafeCharsRegex();

--- a/Agent/Services/FileNamingService.cs
+++ b/Agent/Services/FileNamingService.cs
@@ -29,6 +29,8 @@ public partial class FileNamingService
 
   public bool IsDomainValid(string? domain)
   {
+    if (string.IsNullOrWhiteSpace(domain))
+      return false;
     return Uri.CheckHostName(domain) == UriHostNameType.Dns;
   }
 

--- a/Agent/Services/FileNamingService.cs
+++ b/Agent/Services/FileNamingService.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace Agent.Services;
 
-public partial class FileNamingService : IFileNamingService
+public partial class FileNamingService
 {
     private const string AllowedExtension = ".zip";
     private const string FilePrefix = "slice";

--- a/Agent/Services/FileNamingService.cs
+++ b/Agent/Services/FileNamingService.cs
@@ -4,31 +4,36 @@ namespace Agent.Services;
 
 public partial class FileNamingService
 {
-    private const string AllowedExtension = ".zip";
-    private const string FilePrefix = "slice";
+  private const string AllowedExtension = ".zip";
+  private const string FilePrefix = "slice";
 
-    [GeneratedRegex(@"[^a-zA-Z0-9-]")]
-    private static partial Regex SafeCharsRegex();
+  [GeneratedRegex(@"[^a-zA-Z0-9-]")]
+  private static partial Regex SafeCharsRegex();
 
-    public string GetSafeAppName(string filename) => $"{FilePrefix}-{GetRawAppName(filename)}";
+  public string GetSafeAppName(string filename) => $"{FilePrefix}-{GetRawAppName(filename)}";
 
-    public string GetRawAppName(string filename)
-    {
-        var extension = Path.GetExtension(filename).ToLowerInvariant();
-        if (extension != AllowedExtension)
-            throw new ArgumentException($"Only {AllowedExtension} files are accepted.");
+  public string GetRawAppName(string filename)
+  {
+    var extension = Path.GetExtension(filename).ToLowerInvariant();
+    if (extension != AllowedExtension)
+      throw new ArgumentException($"Only {AllowedExtension} files are accepted.");
 
-        var rawName = Path.GetFileNameWithoutExtension(filename);
-        var cleanName = SafeCharsRegex().Replace(rawName, "").ToLowerInvariant();
+    var rawName = Path.GetFileNameWithoutExtension(filename);
+    var cleanName = SafeCharsRegex().Replace(rawName, "").ToLowerInvariant();
 
-        if (string.IsNullOrEmpty(cleanName))
-            throw new ArgumentException("Filename cannot be empty after sanitization.");
+    if (string.IsNullOrEmpty(cleanName))
+      throw new ArgumentException("Filename cannot be empty after sanitization.");
 
-        return cleanName;
-    }
+    return cleanName;
+  }
 
-    public string GetUploadPath(string appName)
-    {
-        return Path.GetRelativePath(Directory.GetCurrentDirectory(), Path.Combine(FilePrefix, appName));
-    }
+  public bool IsDomainValid(string? domain)
+  {
+    return Uri.CheckHostName(domain) == UriHostNameType.Dns;
+  }
+
+  public string GetUploadPath(string appName)
+  {
+    return Path.GetRelativePath(Directory.GetCurrentDirectory(), Path.Combine(FilePrefix, appName));
+  }
 }

--- a/Agent/Services/FileNamingService.cs
+++ b/Agent/Services/FileNamingService.cs
@@ -10,7 +10,9 @@ public partial class FileNamingService
     [GeneratedRegex(@"[^a-zA-Z0-9-]")]
     private static partial Regex SafeCharsRegex();
 
-    public string GetSafeAppName(string filename)
+    public string GetSafeAppName(string filename) => $"{FilePrefix}-{GetRawAppName(filename)}";
+
+    public string GetRawAppName(string filename)
     {
         var extension = Path.GetExtension(filename).ToLowerInvariant();
         if (extension != AllowedExtension)
@@ -22,7 +24,7 @@ public partial class FileNamingService
         if (string.IsNullOrEmpty(cleanName))
             throw new ArgumentException("Filename cannot be empty after sanitization.");
 
-        return $"{FilePrefix}-{cleanName}";
+        return cleanName;
     }
 
     public string GetUploadPath(string appName)

--- a/Agent/Services/Interfaces/IFileNamingService.cs
+++ b/Agent/Services/Interfaces/IFileNamingService.cs
@@ -1,7 +1,0 @@
-namespace Agent.Services;
-
-public interface IFileNamingService
-{
-    string GetSafeAppName(string fileName);
-    string GetUploadPath(string appName);
-}

--- a/Agent/Services/Interfaces/IReverseProxyClient.cs
+++ b/Agent/Services/Interfaces/IReverseProxyClient.cs
@@ -1,0 +1,7 @@
+namespace Agent.Services.Interfaces;
+
+public interface IReverseProxyClient
+{
+    Task RegisterRouteAsync(string appName, string domain, int port, CancellationToken ct = default);
+    Task RemoveRouteAsync(string appName, CancellationToken ct = default);
+}

--- a/Agent/Services/ProcessManager.cs
+++ b/Agent/Services/ProcessManager.cs
@@ -86,7 +86,7 @@ public partial class ProcessManager
     CreateNoWindow = true,
   })?.WaitForExit();
 
-  public async Task CreateSystemdService(string appName, string dllName)
+  public async Task<int> CreateSystemdService(string appName, string dllName)
   {
     string appDir = Path.GetFullPath(Path.Combine("slice", appName));
     int? nullablePort = _portManager.ReserveNextPort();
@@ -102,6 +102,7 @@ public partial class ProcessManager
     File.WriteAllText(servicePath, serviceContent);
 
     await RunService(appName);
+    return port;
   }
 
   private (string, string) ConstructCustomDomainUrl(string appName, int port)

--- a/Agent/Services/ProcessManager.cs
+++ b/Agent/Services/ProcessManager.cs
@@ -32,7 +32,8 @@ public partial class ProcessManager
     };
 
     using var process = Process.Start(psi);
-    if (process == null)
+
+    if (process is null)
       throw new SystemctlException("Failed to start systemctl for service discovery.");
 
     string output = await process.StandardOutput.ReadToEndAsync();
@@ -55,19 +56,19 @@ public partial class ProcessManager
     ];
   }
 
-  private Task RunService(string appName)
+  private async Task RunService(string appName)
   {
-    RunSystemctlUser("daemon-reload");
+    await RunSystemctlUser("daemon-reload");
 
     bool isActive = IsServiceActive(appName);
-    RunSystemctlUser(isActive ? $"restart {appName}.service" : $"enable --now {appName}.service");
-
-    return Task.CompletedTask;
+    await RunSystemctlUser(isActive ? $"restart {appName}.service" : $"enable --now {appName}.service");
+    return;
   }
 
   private bool IsServiceActive(string appName)
   {
-    using var process = Process.Start(new ProcessStartInfo
+    using var process =
+    Process.Start(new ProcessStartInfo
     {
       FileName = _systemctlBinary,
       Arguments = $"--user is-active {appName}.service",
@@ -78,13 +79,14 @@ public partial class ProcessManager
     return process?.ExitCode == 0;
   }
 
-  private void RunSystemctlUser(string args) => Process.Start(new ProcessStartInfo
-  {
-    FileName = _systemctlBinary,
-    Arguments = $"--user {args}",
-    UseShellExecute = false,
-    CreateNoWindow = true,
-  })?.WaitForExit();
+  private async Task RunSystemctlUser(string args) =>
+   Process.Start(new ProcessStartInfo
+   {
+     FileName = _systemctlBinary,
+     Arguments = $"--user {args}",
+     UseShellExecute = false,
+     CreateNoWindow = true,
+   })?.WaitForExitAsync();
 
   public async Task<int> CreateSystemdService(string appName, string dllName)
   {
@@ -105,14 +107,14 @@ public partial class ProcessManager
     return port;
   }
 
-  private (string, string) ConstructCustomDomainUrl(string appName, int port)
+  private static (string, string) ConstructCustomDomainUrl(string appName, int port)
   {
-    var domain = appName.ToString() + ".localhost";
+    var domain = appName + ".localhost";
     var url = $"http://{domain}:{port}";
     return (domain, url);
   }
 
-  private string ConstructServicefile(string appName, string dllName, string appDir, int port)
+  private static string ConstructServicefile(string appName, string dllName, string appDir, int port)
   {
     var (domain, url) = ConstructCustomDomainUrl(appName, port);
     var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT")

--- a/Agent/Services/ProcessManager.cs
+++ b/Agent/Services/ProcessManager.cs
@@ -36,9 +36,11 @@ public partial class ProcessManager
     if (process is null)
       throw new SystemctlException("Failed to start systemctl for service discovery.");
 
-    string output = await process.StandardOutput.ReadToEndAsync();
-    string error = await process.StandardError.ReadToEndAsync();
+    Task<string> readOutput = process.StandardOutput.ReadToEndAsync();
+    Task<string> readError = process.StandardError.ReadToEndAsync();
     await process.WaitForExitAsync();
+    string output = await readOutput;
+    string error = await readError;
 
     if (process.ExitCode != 0)
       throw new SystemctlException($"systemctl failed while listing services: {error.Trim()}");
@@ -59,24 +61,22 @@ public partial class ProcessManager
   private async Task RunService(string appName)
   {
     await RunSystemctlUser("daemon-reload");
-
-    bool isActive = IsServiceActive(appName);
+    bool isActive = await IsServiceActiveAsync(appName);
     await RunSystemctlUser(isActive ? $"restart {appName}.service" : $"enable --now {appName}.service");
-    return;
   }
 
-  private bool IsServiceActive(string appName)
+  private async Task<bool> IsServiceActiveAsync(string appName)
   {
-    using var process =
-    Process.Start(new ProcessStartInfo
+    using var process = Process.Start(new ProcessStartInfo
     {
       FileName = _systemctlBinary,
       Arguments = $"--user is-active {appName}.service",
       UseShellExecute = false,
       CreateNoWindow = true,
     });
-    process?.WaitForExit();
-    return process?.ExitCode == 0;
+    if (process is null) return false;
+    await process.WaitForExitAsync();
+    return process.ExitCode == 0;
   }
 
   private async Task RunSystemctlUser(string args)

--- a/Agent/Services/ProcessManager.cs
+++ b/Agent/Services/ProcessManager.cs
@@ -79,16 +79,19 @@ public partial class ProcessManager
     return process?.ExitCode == 0;
   }
 
-  private async Task RunSystemctlUser(string args) =>
-   Process.Start(new ProcessStartInfo
-   {
-     FileName = _systemctlBinary,
-     Arguments = $"--user {args}",
-     UseShellExecute = false,
-     CreateNoWindow = true,
-   })?.WaitForExitAsync();
+  private async Task RunSystemctlUser(string args)
+  {
+    var process = Process.Start(new ProcessStartInfo
+    {
+      FileName = _systemctlBinary,
+      Arguments = $"--user {args}",
+      UseShellExecute = false,
+      CreateNoWindow = true,
+    }) ?? throw new InvalidOperationException($"Failed to start systemctl with args: {args}");
+    await process.WaitForExitAsync();
+  }
 
-  public async Task<int> CreateSystemdService(string appName, string dllName)
+  public async Task<int> CreateSystemdService(string appName, string dllName, string? allowedHost = null)
   {
     string appDir = Path.GetFullPath(Path.Combine("slice", appName));
     int? nullablePort = _portManager.ReserveNextPort();
@@ -97,7 +100,7 @@ public partial class ProcessManager
         throw new OutOfPortsException() :
         (int)nullablePort;
 
-    string serviceContent = ConstructServicefile(appName, dllName, appDir, port);
+    string serviceContent = ConstructServicefile(appName, dllName, appDir, port, allowedHost);
 
     var servicePath = Path.Combine(_targetDir, $"{appName}.service");
     Directory.CreateDirectory(_targetDir);
@@ -114,9 +117,10 @@ public partial class ProcessManager
     return (domain, url);
   }
 
-  private static string ConstructServicefile(string appName, string dllName, string appDir, int port)
+  private static string ConstructServicefile(string appName, string dllName, string appDir, int port, string? allowedHost = null)
   {
     var (domain, url) = ConstructCustomDomainUrl(appName, port);
+    var hostFilter = allowedHost ?? domain;
     var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT")
         ?? throw new InvalidOperationException("DOTNET_ROOT is not set. Ensure dotnet is installed and DOTNET_ROOT is configured.");
     var dotnetExe = Path.Combine(dotnetRoot, "dotnet");
@@ -135,7 +139,7 @@ public partial class ProcessManager
         Environment=ASPNETCORE_HTTP_PORTS={port}
         Environment=ASPNETCORE_URLS={url}
         Environment=ASPNETCORE_ENVIRONMENT=Production
-        Environment=ASPNETCORE_HOSTFILTERING__ALLOWEDHOSTS={domain}
+        Environment=ASPNETCORE_HOSTFILTERING__ALLOWEDHOSTS={hostFilter}
         Environment=DOTNET_ROOT={dotnetRoot}
 
         [Install]

--- a/Agent/Services/ProcessManager.cs
+++ b/Agent/Services/ProcessManager.cs
@@ -81,14 +81,18 @@ public partial class ProcessManager
 
   private async Task RunSystemctlUser(string args)
   {
-    var process = Process.Start(new ProcessStartInfo
+    using var process = Process.Start(new ProcessStartInfo
     {
       FileName = _systemctlBinary,
       Arguments = $"--user {args}",
       UseShellExecute = false,
       CreateNoWindow = true,
+      RedirectStandardError = true,
     }) ?? throw new InvalidOperationException($"Failed to start systemctl with args: {args}");
+    string error = await process.StandardError.ReadToEndAsync();
     await process.WaitForExitAsync();
+    if (process.ExitCode != 0)
+      throw new SystemctlException($"systemctl --user {args} failed: {error.Trim()}");
   }
 
   public async Task<int> CreateSystemdService(string appName, string dllName, string? allowedHost = null)

--- a/Agent/appsettings.json
+++ b/Agent/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ReverseProxy": {
+    "AdminUrl": "http://localhost:2019",
+    "BaseDomain": "naslice.duckdns.org"
+  }
 }

--- a/Agent/appsettings.json
+++ b/Agent/appsettings.json
@@ -8,6 +8,6 @@
   "AllowedHosts": "*",
   "ReverseProxy": {
     "AdminUrl": "http://localhost:2019",
-    "BaseDomain": "naslice.duckdns.org"
+    "BaseDomain": ""
   }
 }

--- a/Common/Models/DeployResult.cs
+++ b/Common/Models/DeployResult.cs
@@ -1,0 +1,3 @@
+namespace Slice.Common.Models;
+
+public record DeployResult(string AppName, string? PublicUrl = null);

--- a/Docs/server-setup.md
+++ b/Docs/server-setup.md
@@ -2,14 +2,58 @@
 
 No Docker yet — this is early and experimental. You set it up manually.
 
+> **Security warning:** Authentication is not yet implemented. Do not expose port 5165 publicly or put it behind a reverse proxy that makes it reachable from the internet. Access it only over a VPN or local network. Auth is planned — this restriction is temporary.
+
 ---
 
 ## Prerequisites
 
 - Linux with systemd (Raspberry Pi, VPS, anything)
-- .NET 10 runtime with `Microsoft.AspNetCore.App` — not just the base runtime
+- .NET 10 SDK — needed to build the agent on the server
 
-Check after installing:
+---
+
+## Step 1 — Get the code on your server
+
+SSH into your server, then clone the repo:
+
+```bash
+git clone https://github.com/n4sser77/slice.git
+cd slice
+```
+
+If you already have it and just want to update:
+
+```bash
+cd ~/slice
+git pull
+```
+
+---
+
+## Step 2 — Build the agent
+
+Two options depending on your preference:
+
+**Option A — AOT native binary (recommended)**
+
+No .NET runtime needed to run the agent. Self-contained binary.
+
+```bash
+dotnet publish Agent -c Release
+```
+
+Output: `Agent/bin/Release/net10.0/linux-arm64/publish/Agent`
+
+**Option B — Framework-dependent**
+
+Smaller build, but requires the .NET 10 runtime with `Microsoft.AspNetCore.App` installed on the server.
+
+```bash
+dotnet publish Agent -c Release -p:PublishAot=false --output ./agent-out
+```
+
+Check that the runtime is available:
 
 ```bash
 dotnet --list-runtimes
@@ -18,35 +62,30 @@ dotnet --list-runtimes
 
 ---
 
-## Step 1 — Clone the repo on your server
-
-SSH into your server, then:
-
-```bash
-git clone https://github.com/n4sser77/slice.git
-cd slice
-```
-
----
-
-## Step 2 — Publish the agent
-
-```bash
-dotnet publish Agent --configuration Release --output ./agent-out
-```
-
----
-
 ## Step 3 — Create the systemd service
-
-Create the file `~/.config/systemd/user/slice-agent.service`:
 
 ```bash
 mkdir -p ~/.config/systemd/user
 nano ~/.config/systemd/user/slice-agent.service
 ```
 
-Paste this — **replace the paths with your own**:
+**If you used Option A (AOT)** — replace `<your-user>` with your username:
+
+```ini
+[Unit]
+Description=Slice Agent
+
+[Service]
+WorkingDirectory=/home/<your-user>/slice/Agent/bin/Release/net10.0/linux-arm64/publish
+ExecStart=/home/<your-user>/slice/Agent/bin/Release/net10.0/linux-arm64/publish/Agent
+Restart=always
+Environment=ASPNETCORE_HTTP_PORTS=5165
+
+[Install]
+WantedBy=default.target
+```
+
+**If you used Option B (framework-dependent)** — you need the `dotnet` path and `DOTNET_ROOT`:
 
 ```ini
 [Unit]
@@ -63,9 +102,7 @@ Environment=DOTNET_ROOT=<your-dotnet-root>
 WantedBy=default.target
 ```
 
-### Finding your paths
-
-Run these on the server to get the right values:
+### Finding your paths (Option B only)
 
 ```bash
 which dotnet          # → use this for ExecStart
@@ -100,16 +137,104 @@ The agent is now running on port 5165.
 
 ---
 
-## Step 5 — Point your CLI at it
+## Step 5 — Set up Caddy (required for public URLs)
 
-On your local machine:
+Caddy acts as the reverse proxy. It routes traffic from `myapp.yourdomain.com` to the right app and handles HTTPS automatically via Let's Encrypt.
+
+Install:
+
+```bash
+sudo apt install -y caddy
+```
+
+Create a minimal Caddyfile at `/etc/caddy/Caddyfile`:
+
+```
+{
+    admin localhost:2019
+    email your@email.com
+}
+
+:80, :443 {
+}
+```
+
+Start it:
+
+```bash
+sudo systemctl enable --now caddy
+```
+
+Verify the admin API is up:
+
+```bash
+curl http://localhost:2019/config/
+```
+
+Make sure your router forwards **port 80** and **port 443** to your server — Let's Encrypt needs port 80 to issue certificates.
+
+---
+
+## Step 6 — Configure the agent
+
+The agent reads reverse proxy settings from `appsettings.json` in the publish directory. The defaults are:
+
+```json
+"ReverseProxy": {
+  "AdminUrl": "http://localhost:2019",
+  "BaseDomain": "naslice.duckdns.org"
+}
+```
+
+Change `BaseDomain` to your own domain if needed.
+
+---
+
+## Step 7 — Point your CLI at the server
+
+On your local machine, set the agent URL:
 
 ```bash
 export SLICE_AGENT_URL=http://<your-server-ip>:5165
+```
+
+Add it to `~/.bashrc` or `~/.zshrc` to make it permanent.
+
+Verify it works:
+
+```bash
+slice list
+```
+
+---
+
+## Deploying apps
+
+```bash
+# Deploy — app runs on localhost only (safe default)
 slice deploy MyApp
+
+# Deploy and expose publicly at myapp.<base-domain>
+slice deploy MyApp --publish
+
+# Deploy with a custom domain
+slice deploy MyApp --publish --domain myapp.example.com
 ```
 
 > The agent has no authentication yet — make sure port 5165 is only reachable from machines you trust. Don't expose it publicly.
+
+---
+
+## Updating the agent
+
+If you already have the repo and want to upgrade:
+
+```bash
+cd ~/slice
+git pull
+dotnet publish Agent -c Release   # or whichever option you used initially
+systemctl --user restart slice-agent.service
+```
 
 ---
 

--- a/Docs/server-setup.md
+++ b/Docs/server-setup.md
@@ -182,7 +182,7 @@ The agent reads reverse proxy settings from `appsettings.json` in the publish di
 ```json
 "ReverseProxy": {
   "AdminUrl": "http://localhost:2019",
-  "BaseDomain": "naslice.duckdns.org"
+  "BaseDomain": "your-domain.example.com"
 }
 ```
 

--- a/Docs/server-setup.md
+++ b/Docs/server-setup.md
@@ -40,7 +40,7 @@ Two options depending on your preference:
 No .NET runtime needed to run the agent. Self-contained binary.
 
 ```bash
-dotnet publish Agent -c Release
+dotnet publish Agent -c Release -r linux-arm64
 ```
 
 Output: `Agent/bin/Release/net10.0/linux-arm64/publish/Agent`

--- a/README.md
+++ b/README.md
@@ -28,15 +28,24 @@ dotnet pack Agent.Cli --configuration Release
 dotnet tool install --global --add-source ./Agent.Cli/bin/Release slice
 ```
 
+Point the CLI at your server:
+
+```bash
+export SLICE_AGENT_URL=http://<your-server-ip>:5165
+```
+
 Once installed, the `slice` command is available everywhere on your machine:
 
 ```bash
-slice deploy MyApp
+slice deploy MyApp                                         # localhost only
+slice deploy MyApp --publish                               # public HTTPS URL
+slice deploy MyApp --publish --domain myapp.example.com   # custom domain
 slice list
 slice status MyApp
+slice stop MyApp
 ```
 
-The CLI packages your app, sends it to the agent running on your server, and the agent handles the rest — systemd service, port, everything.
+The CLI packages your app, sends it to the agent running on your server, and the agent handles the rest — systemd service, port, and optionally a public HTTPS URL via Caddy.
 
 **The agent needs to be running on your server first.** See [Docs/server-setup.md](Docs/server-setup.md) for how to get it running.
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ slice deploy MyApp                                         # localhost only
 slice deploy MyApp --publish                               # public HTTPS URL
 slice deploy MyApp --publish --domain myapp.example.com   # custom domain
 slice list
-slice status MyApp
-slice stop MyApp
+slice status myapp
+slice stop myapp
 ```
 
 The CLI packages your app, sends it to the agent running on your server, and the agent handles the rest — systemd service, port, and optionally a public HTTPS URL via Caddy.


### PR DESCRIPTION
After deploying a service remotely there is no way to reach, user doesn't know what port it is hosted on and without a vpn there is no way to access it. This beats the purpose of this system to avoid manual steps in deployment.

Introduced Reverse proxy integration, that can be configured to use the appname as a subdomain of a base-domain, or deploy with a --domain flag to choose a custom domain. This will be injected to caddy using its admin api.

Users must specify --publish to avoid accidental public deploys. Otherwise it should deploy on localhost.
closes: #4 