### PR TITLE
feat: add `slice remove` command to fully delete deployed services

### DIFF
--- a/Agent.Cli/Commands/RemoveServiceCommand.cs
+++ b/Agent.Cli/Commands/RemoveServiceCommand.cs
@@ -1,18 +1,18 @@
 using System.CommandLine;
+using System.Net;
+using System.Runtime.CompilerServices;
 using Agent.Cli.Core;
 using Agent.Cli.Core.Events;
-using Agent.Cli.Presentation;
 using Agent.Cli.Core.Results;
-using System.Runtime.CompilerServices;
-using System.Net;
+using Agent.Cli.Presentation;
 
 namespace Agent.Cli.Commands;
 
-public class StopServiceCommand(string serviceName, HttpClient httpClient) : ICommand
+public class RemoveServiceCommand(string serviceName, HttpClient httpClient) : ICommand
 {
   public static void Register(RootCommand root, HttpClient httpClient, CliConfig? config = null)
   {
-    Command command = new("stop", "Stops a running service.");
+    Command command = new("remove", "Remove a deployed service and free its resources.");
     Argument<string> serviceNameArg = new("service-name")
     {
       Description = "The name of the service without the 'slice-' prefix and '.service' suffix."
@@ -23,32 +23,35 @@ public class StopServiceCommand(string serviceName, HttpClient httpClient) : ICo
     {
       var raw = parseResult.GetValue(serviceNameArg)!;
       var name = raw.EndsWith(".service", StringComparison.OrdinalIgnoreCase) ? raw.Substring(0, raw.Length - ".service".Length) : raw;
-      var cmd = new StopServiceCommand(name, httpClient);
+      var cmd = new RemoveServiceCommand(name, httpClient);
       return await ConsoleRenderer.RenderAsync(cmd.ExecuteStreamingAsync(ct), ct);
     });
 
     root.Subcommands.Add(command);
-
   }
 
   public async IAsyncEnumerable<ExecutionEvent> ExecuteStreamingAsync(
-    [EnumeratorCancellation] CancellationToken ct = default)
+      [EnumeratorCancellation] CancellationToken ct = default)
   {
-    var (_, err) = await TryStopService(ct);
+    yield return new StepStarted("Removing service");
+
+    var (_, err) = await TryRemoveService(ct);
     if (err is ErrorResult errorResult)
     {
+      yield return new StepFailed("Removing service", errorResult.Message);
       yield return new FinalResult(errorResult);
       yield break;
     }
 
-    yield return new FinalResult(new SuccessResult($"Stopped {serviceName}"));
+    yield return new StepCompleted("Removing service", TimeSpan.Zero);
+    yield return new FinalResult(new SuccessResult($"Removed {serviceName}"));
   }
 
-  private async Task<(bool stopped, ErrorResult? err)> TryStopService(CancellationToken ct)
+  private async Task<(bool removed, ErrorResult? err)> TryRemoveService(CancellationToken ct)
   {
     try
     {
-      var response = await httpClient.PostAsync($"services/{serviceName}/stop", null, ct);
+      var response = await httpClient.DeleteAsync($"services/{serviceName}", ct);
 
       if (response.StatusCode == HttpStatusCode.NotFound)
         return (false, new ErrorResult($"Service '{serviceName}' not found.", 1));

--- a/Agent.Cli/Program.cs
+++ b/Agent.Cli/Program.cs
@@ -16,5 +16,6 @@ DeployServiceCommand.Register(root, httpClient, config);
 GetServicesCommand.Register(root, httpClient);
 GetServiceStatusCommand.Register(root, httpClient);
 StopServiceCommand.Register(root, httpClient);
+RemoveServiceCommand.Register(root, httpClient);
 
 return await root.Parse(args).InvokeAsync();

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -173,4 +173,48 @@ app.MapPost("v1/services/{serviceName}/stop", async (string serviceName, Process
                         statusCode: (int)HttpStatusCode.InternalServerError);
 });
 
+app.MapDelete("v1/services/{serviceName}", async (
+    string serviceName,
+    ProcessManager processRunner,
+    IPortManager portManager,
+    IReverseProxyClient proxy) =>
+{
+  var fullName = $"{FileNamingService.FilePrefix}-{serviceName}";
+  if (!FileNamingService.IsValidServiceName(fullName))
+    return Results.Problem(detail: "Invalid service name.", statusCode: (int)HttpStatusCode.BadRequest);
+
+  var servicePath = Path.Combine(
+      Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+      ".config/systemd/user/", $"{fullName}.service");
+
+  if (!File.Exists(servicePath))
+    return Results.NotFound();
+
+  try
+  {
+    var port = processRunner.GetServicePortFromFile(fullName);
+
+    await processRunner.DeleteServiceAsync(fullName);
+
+    if (port is not null)
+      portManager.ReleasePort(port.Value);
+
+    try
+    {
+      await proxy.RemoveRouteAsync(fullName);
+    }
+    catch
+    {
+      // Caddy route may not exist — that's fine
+    }
+
+    return Results.NoContent();
+  }
+  catch (Exception ex)
+  {
+    return Results.Problem(detail: $"Failed to remove service '{serviceName}': {ex.Message}",
+                           statusCode: (int)HttpStatusCode.InternalServerError);
+  }
+});
+
 app.Run();

--- a/Agent/Services/ProcessManager.cs
+++ b/Agent/Services/ProcessManager.cs
@@ -186,4 +186,48 @@ public partial class ProcessManager
 
     return process.ExitCode == 0;
   }
+
+  public async Task DeleteServiceAsync(string serviceName)
+  {
+    string svc = $"{serviceName}.service";
+
+    await RunSystemctlUser($"stop {svc}");
+    await RunSystemctlUser($"disable {svc}");
+
+    var servicePath = Path.Combine(_targetDir, svc);
+    if (File.Exists(servicePath))
+      File.Delete(servicePath);
+
+    await RunSystemctlUser("daemon-reload");
+
+    var appDir = Path.GetFullPath(Path.Combine("slice", serviceName));
+    if (Directory.Exists(appDir))
+      Directory.Delete(appDir, recursive: true);
+  }
+
+  public int? GetServicePortFromFile(string serviceName)
+  {
+    var servicePath = Path.Combine(_targetDir, $"{serviceName}.service");
+    if (!File.Exists(servicePath))
+      return null;
+
+    var lines = File.ReadAllLines(servicePath);
+    foreach (var line in lines)
+    {
+      if (line.StartsWith("Environment=ASPNETCORE_HTTP_PORTS=", StringComparison.Ordinal))
+      {
+        var val = line["Environment=ASPNETCORE_HTTP_PORTS=".Length..].Trim();
+        if (int.TryParse(val, out var port))
+          return port;
+      }
+      if (line.StartsWith("Environment=ASPNETCORE_URLS=", StringComparison.Ordinal))
+      {
+        var val = line["Environment=ASPNETCORE_URLS=".Length..].Trim();
+        var lastColon = val.LastIndexOf(':');
+        if (lastColon >= 0 && int.TryParse(val[(lastColon + 1)..], out var port))
+          return port;
+      }
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
Implements `slice remove <service-name>` which cleans up all resources: stops/disables the systemd unit, deletes the service file, removes uploaded app files, releases the port, and deletes the Caddy route.

- Agent/ProcessManager: Add DeleteServiceAsync and GetServicePortFromFile for full resource teardown
- Agent/Program.cs: Add DELETE /v1/services/{serviceName} endpoint
- CLI/RemoveServiceCommand: New command following existing patterns
- CLI/Program.cs: Register remove command
- Clean up range/index syntax in StopServiceCommand for readability